### PR TITLE
Make widget order consistent

### DIFF
--- a/lib/gac/block.rb
+++ b/lib/gac/block.rb
@@ -202,7 +202,8 @@ class GAC::Block
   # Return the next faust UI widget number
   #
   def wnum
-    s = "[#{@widget_idx}]"
+    wstr = "%04d" % @widget_idx
+    s = "[#{wstr}]"
     @widget_idx += 1
     s
   end

--- a/lib/gac/panel.rb
+++ b/lib/gac/panel.rb
@@ -173,7 +173,8 @@ EOS
     s << @output_names.join(",\n")
     s << ") = tgroup(\"top\","
     @block.each_with_index do |block,n|
-      t << "vgroup(\"[#{n}]#{block.name}\",#{block.fn_call})"
+      wstr = "%04d" % n
+      t << "vgroup(\"[#{wstr}]#{block.name}\",#{block.fn_call})"
     end
     s << t.join(",\n")
     s << ");"


### PR DESCRIPTION
Zero pad widget metadata so that the UI widget order comes out as
expected.